### PR TITLE
feat: configuring chalk for signing via setup

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: read
 
+env:
+  COSIGN_PASSWORD: 6EHvWD1BUk0yWdvm-GGNxA==
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -21,8 +24,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@main
+
+      - name: Generate key
+        run: |
+          cosign \
+            generate-key-pair \
+            --output-key-prefix chalk
+          {
+            echo 'PUBLIC_KEY<<EOF'
+            cat chalk.pub
+            echo EOF
+          } >> "$GITHUB_ENV"
+          {
+            echo 'PRIVATE_KEY<<EOF'
+            cat chalk.key
+            echo EOF
+          } >> "$GITHUB_ENV"
+
       - name: Setup Chalk
         uses: ./
+        with:
+          version: cecbf150e2fe0df7a813a8c4cb2923ba62b1fe40
+          password: ${{ env.COSIGN_PASSWORD }}
+          public_key: ${{ env.PUBLIC_KEY }}
+          private_key: ${{ env.PRIVATE_KEY }}
 
       - name: Verify Setup
         run: |
@@ -30,5 +57,7 @@ jobs:
           set -x
           which chalk
           which docker
+          strings $(which chalk) | tail -n 18 | head -n1 | jq
+          strings $(which docker) | tail -n 18 | head -n1 | jq
           chalk version
           docker version

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 tags
 .envrc
+*.pub
+*.key

--- a/README.md
+++ b/README.md
@@ -37,12 +37,15 @@ jobs:
 
 The following parameters can be provided to the action.
 
-| Name      | Type   | Default | Description                                                                                                                                     |
-| --------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version` | String |         | Version of chalk to install. By default latest version is installed. See [releases] for all available versions.                                 |
-| `load`    | String |         | Chalk config(s) to load - comma or new-line delimited. Can be either paths to files or URLs.                                                    |
-| `params`  | String |         | Chalk components params to load. Should be JSON array with all parameter values. JSON structure is the same as provided by `chalk dump params`. |
-| `token`   | String |         | CrashOverride API Token. Get your API token at [CrashOverride]                                                                                  |
+| Name          | Type   | Default | Description                                                                                                                                     |
+| ------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`     | String |         | Version of chalk to install. By default latest version is installed. See [releases] for all available versions.                                 |
+| `load`        | String |         | Chalk config(s) to load - comma or new-line delimited. Can be either paths to files or URLs.                                                    |
+| `params`      | String |         | Chalk components params to load. Should be JSON array with all parameter values. JSON structure is the same as provided by `chalk dump params`. |
+| `token`       | String |         | CrashOverride API Token. Get your API token at [CrashOverride]                                                                                  |
+| `password`    | String |         | Password for chalk signing key. Password is displayed as part of `chalk setup`.                                                                 |
+| `public_key`  | String |         | Content of chalk signing public key). Copy from `chalk.pub` after `chalk setup`.                                                                |
+| `private_key` | String |         | Content of chalk signing encrypted private key (with the provided password). Copy from `chalk.key` after `chalk setup`.                         |
 
 For example:
 
@@ -53,6 +56,9 @@ For example:
     version: "0.3.0"
     load: "https://chalkdust.io/connect.c4m"
     token: ${{ secrets.CHALK_TOKEN }}
+    password: ${{ secrets.CHALK_PASSWORD }}
+    public_key: ${{ secrets.CHALK_PUBLIC_KEY }}
+    private_key: ${{ secrets.CHALK_PRIVATE_KEY }}
 ```
 
 [chalk]: https://github.com/crashappsec/chalk/

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,21 @@ inputs:
       CrashOverride API Token.
       Get your API token at CrashOverride: https://crashoverride.run
     required: false
+  password:
+    description: |
+      Password for chalk signing key.
+      Password is displayed as part of `chalk setup`.
+    required: false
+  public_key:
+    description: |
+      Content of chalk signing public key).
+      Copy from `chalk.pub` after `chalk setup`.
+    required: false
+  private_key:
+    description: |
+      Content of chalk signing encrypted private key (with the provided password).
+      Copy from `chalk.key` after `chalk setup`.
+    required: false
 
 runs:
   using: "composite"
@@ -40,6 +55,30 @@ runs:
       run: |
         echo "$HOME/.chalk/bin" >> $GITHUB_PATH
 
+    - name: Set CHALK_PASSWORD
+      if: inputs.password != ''
+      shell: bash
+      run: |
+        echo "CHALK_PASSWORD=${{ inputs.password }}" >> $GITHUB_ENV
+
+    - name: Save Public Key
+      if: inputs.public_key != ''
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      env:
+        CHALK_PUBLIC_KEY: "${{ inputs.public_key }}"
+      run: |
+        printenv CHALK_PUBLIC_KEY > chalk.pub
+
+    - name: Save Private Key
+      if: inputs.private_key != ''
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      env:
+        CHALK_PRIVATE_KEY: "${{ inputs.private_key }}"
+      run: |
+        printenv CHALK_PRIVATE_KEY > chalk.key
+
     - name: Set up chalk
       if: runner.os == 'Linux' || runner.os == 'macOS'
       shell: bash
@@ -51,4 +90,6 @@ runs:
           --params='${{ inputs.params }}' \
           --token='${{ inputs.token }}' \
           --prefix=$HOME/.chalk \
+          ${{ inputs.public_key != '' && format('--public-key={0}/chalk.pub', github.action_path) || '' }} \
+          ${{ inputs.private_key != '' && format('--private-key={0}/chalk.key', github.action_path) || '' }} \
           ${{ runner.debug == '1' && '--debug' || '' }}

--- a/setup.sh
+++ b/setup.sh
@@ -47,6 +47,10 @@ copy_from=
 timeout=60
 # which platforms to download for multi-platform builds
 platforms=
+# information for signing
+password=${CHALK_PASSWORD:-}
+public_key=
+private_key=
 
 color() {
     (
@@ -325,6 +329,11 @@ wrap_cmd() {
     info Using "$chalked_path" will automatically use chalk now
 }
 
+copy_keys() {
+    $SUDO cp "$public_key" "$(dirname "$chalk_path")/chalk.pub"
+    $SUDO cp "$private_key" "$(dirname "$chalk_path")/chalk.key"
+}
+
 help() {
     cat << EOF
 Setup chalk:
@@ -360,6 +369,9 @@ Args:
 --timeout=*         Timeout for chalk commands.
                     Default is ${timeout}.
 --platforms=*       Additional platforms to download chalk.
+--public-key=*      Path to signing public key.
+--private-key=*     Path to signing private key encrypted with
+                    CHALK_PASSWORD env var.
 
 Args for debugging:
 
@@ -412,6 +424,12 @@ for arg; do
             ;;
         --platforms=*)
             platforms=${arg##*=}
+            ;;
+        --public-key=*)
+            public_key=${arg##*=}
+            ;;
+        --private-key=*)
+            private_key=${arg##*=}
             ;;
         --help | -h)
             help 0
@@ -473,6 +491,12 @@ done
 if [ -n "$debug" ]; then
     info Debug mode is enabled. Changing default chalk log level to trace
     params='' token='' load=https://chalkdust.io/debug.c4m load_config
+fi
+
+if [ -n "$password" ] && [ -f "$public_key" ] && [ -f "$private_key" ]; then
+    info "Loading signing keys into chalk"
+    copy_keys
+    chalk setup
 fi
 
 if [ -n "$wrap" ]; then

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,6 +8,11 @@ endif
 ifneq "$(COPY)" ""
 ARGS+=--copy-from=/chalk/chalk
 endif
+ifneq "$(CHALK_PASSWORD)" ""
+ARGS+=--public-key=tests/chalk.pub
+ARGS+=--private-key=tests/chalk.key
+DEPS+=chalk.key
+endif
 
 define SETUP=
 set -x && ./setup.sh
@@ -22,7 +27,7 @@ endef
 all: default
 all: prefix
 
-default:
+default: $(DEPS)
 	$(DOCKER) '\
 		$(SETUP) \
 		--version=$(VERSION) \
@@ -34,7 +39,7 @@ default:
 	'
 
 prefix: USER=runner
-prefix:
+prefix: $(DEPS)
 	$(DOCKER) '\
 		$(SETUP) \
 		--version=$(VERSION) \
@@ -48,3 +53,10 @@ prefix:
 
 ubuntu alpine:
 	TARGET=$@ docker compose build
+
+chalk.key:
+	COSIGN_PASSWORD=$(CHALK_PASSWORD) \
+		cosign \
+		generate-key-pair \
+		--output-key-prefix chalk
+	chmod 0644 chalk.key

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       target: ${TARGET:-alpine}
     working_dir: /action
     user: ${USER:-root}
+    environment:
+      CHALK_PASSWORD: ${CHALK_PASSWORD:-}
     volumes:
       - ../:/action
       - ../../chalk:/chalk


### PR DESCRIPTION
this PR adds a few parameters to the action:

* `password`
* `public_key`
* `private_key`

if they are passed in to `setup.sh`, it then internally executes `chalk setup` which allows it to embed the signing keys passed as parameters into the chalk binary. as a result chalk can then sign artifacts via cosign