### PR TITLE
adding connect parameter with openid connect integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following parameters can be provided to the action.
 | `version`     | String |         | Version of chalk to install. By default latest version is installed. See [releases] for all available versions.                                 |
 | `load`        | String |         | Chalk config(s) to load - comma or new-line delimited. Can be either paths to files or URLs.                                                    |
 | `params`      | String |         | Chalk components params to load. Should be JSON array with all parameter values. JSON structure is the same as provided by `chalk dump params`. |
+| `connect`     | Bool   |         | Whether to automatically connect to https://crashoverride.run. If true, will load https://chalkdust.io/connect.c4m.                             |
 | `token`       | String |         | CrashOverride API Token. Get your API token at [CrashOverride]                                                                                  |
 | `password`    | String |         | Password for chalk signing key. Password is displayed as part of `chalk setup`.                                                                 |
 | `public_key`  | String |         | Content of chalk signing public key). Copy from `chalk.pub` after `chalk setup`.                                                                |
@@ -54,6 +55,7 @@ For example:
   uses: crashappsec/setup-chalk-action@main
   with:
     version: "0.3.0"
+    connect: true
     load: "https://chalkdust.io/connect.c4m"
     token: ${{ secrets.CHALK_TOKEN }}
     password: ${{ secrets.CHALK_PASSWORD }}

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,11 @@ inputs:
       JSON structure is the same as provided by
       'chalk dump params'.
     required: false
+  connect:
+    description: |
+      Whether to automatically connect to https://crashoverride.run.
+      If true, will load https://chalkdust.io/connect.c4m.
+    required: false
   token:
     description: |
       CrashOverride API Token.
@@ -56,13 +61,13 @@ runs:
         echo "$HOME/.chalk/bin" >> $GITHUB_PATH
 
     - name: Set CHALK_PASSWORD
-      if: inputs.password != ''
+      if: (runner.os == 'Linux' || runner.os == 'macOS') && inputs.password != ''
       shell: bash
       run: |
         echo "CHALK_PASSWORD=${{ inputs.password }}" >> $GITHUB_ENV
 
     - name: Save Public Key
-      if: inputs.public_key != ''
+      if: (runner.os == 'Linux' || runner.os == 'macOS') && inputs.public_key != ''
       shell: bash
       working-directory: ${{ github.action_path }}
       env:
@@ -71,13 +76,52 @@ runs:
         printenv CHALK_PUBLIC_KEY > chalk.pub
 
     - name: Save Private Key
-      if: inputs.private_key != ''
+      if: (runner.os == 'Linux' || runner.os == 'macOS') && inputs.private_key != ''
       shell: bash
       working-directory: ${{ github.action_path }}
       env:
         CHALK_PRIVATE_KEY: "${{ inputs.private_key }}"
       run: |
         printenv CHALK_PRIVATE_KEY > chalk.key
+
+    - name: Save provided JWT token
+      if: (runner.os == 'Linux' || runner.os == 'macOS') && inputs.token != ''
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        echo "${{ inputs.token }}" > chalk.jwt
+
+    - name: Get JWT by using GitHub OpenId Connect
+      if: (runner.os == 'Linux' || runner.os == 'macOS') && inputs.connect != '' && inputs.connect != 'false' && inputs.token == ''
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        curl \
+          --fail \
+          --silent \
+          --header "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://crashoverride.run" \
+          > github.jwt || (
+          echo "Cannot generate GitHub OpenId Connect JWT Token."
+          echo "Please make sure workflow/job has 'id-token: write' permission."
+          echo "See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings"
+          exit 1
+        )
+        curl \
+          --fail \
+          --silent \
+          --request POST \
+          --data-binary @github.jwt \
+          --header 'Content-Type: application/json' \
+          https://chalk.crashoverride.run/v0.1/openid-connect/github \
+          | jq -r '.jwt' \
+          > chalk.jwt || (
+          echo "Could not retrieve Chalk JWT token."
+          echo "Please make sure GitHub integration is configured in your CrashOverride workspace."
+          exit 1
+        )
+        echo "::add-mask::$(cat chalk.jwt)"
+        echo "chalk_token=$(cat chalk.jwt)" >> $GITHUB_OUTPUT
 
     - name: Set up chalk
       if: runner.os == 'Linux' || runner.os == 'macOS'
@@ -88,7 +132,7 @@ runs:
           --version='${{ inputs.version }}' \
           --load='${{ inputs.load }}' \
           --params='${{ inputs.params }}' \
-          --token='${{ inputs.token }}' \
+          --token="$(cat chalk.jwt 2> /dev/null)" \
           --prefix=$HOME/.chalk \
           ${{ inputs.public_key != '' && format('--public-key={0}/chalk.pub', github.action_path) || '' }} \
           ${{ inputs.private_key != '' && format('--private-key={0}/chalk.key', github.action_path) || '' }} \


### PR DESCRIPTION
this adds `connect` input to the action. When enabled it uses [openid connect](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) to JWT from GitHub which asserts the origin of the workflow. That token is then passed to chalk data api to fetch chalk JWT to be embedded in chalk. This chalk can be connected to crashoverride.run without storing/managing any secrets.

Only nuance here is that `id_token: write` permission is required. Otherwise JWT from GitHub cannot be fetched.