### PR TITLE
adding --setup flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -121,7 +121,6 @@ runs:
           exit 1
         )
         echo "::add-mask::$(cat chalk.jwt)"
-        echo "chalk_token=$(cat chalk.jwt)" >> $GITHUB_OUTPUT
 
     - name: Set up chalk
       if: runner.os == 'Linux' || runner.os == 'macOS'
@@ -134,6 +133,7 @@ runs:
           --params='${{ inputs.params }}' \
           --token="$(cat chalk.jwt 2> /dev/null)" \
           --prefix=$HOME/.chalk \
+          ${{ inputs.connect == 'true' && '--setup' || '' }} \
           ${{ inputs.public_key != '' && format('--public-key={0}/chalk.pub', github.action_path) || '' }} \
           ${{ inputs.private_key != '' && format('--private-key={0}/chalk.key', github.action_path) || '' }} \
           ${{ runner.debug == '1' && '--debug' || '' }}

--- a/setup.sh
+++ b/setup.sh
@@ -52,6 +52,8 @@ platforms=${CHALK_PLATFORMS:-}
 password=${CHALK_PASSWORD:-}
 public_key=${CHALK_PUBLIC_KEY:-}
 private_key=${CHALK_PRIVATE_KEY:-}
+# run chalk setup
+setup=${CHALK_SETUP:-}
 
 color() {
     (
@@ -373,6 +375,8 @@ Args:
 --public-key=*      Path to signing public key.
 --private-key=*     Path to signing private key encrypted with
                     CHALK_PASSWORD env var.
+--setup             Run chalk setup. Also setup automatically runs
+                    if --public-key and --private-key are provided.
 
 Args for debugging:
 
@@ -411,6 +415,9 @@ for arg; do
             ;;
         --debug)
             enable_debug
+            ;;
+        --setup)
+            setup=true
             ;;
         --overwrite)
             overwrite=true
@@ -505,6 +512,9 @@ fi
 if [ -n "$password" ] && [ -f "$public_key" ] && [ -f "$private_key" ]; then
     info "Loading signing keys into chalk"
     copy_keys
+    chalk setup
+elif [ -n "$setup" ]; then
+    info "Setting up chalk attestation"
     chalk setup
 fi
 


### PR DESCRIPTION
this will allow users of https://github.com/crashappsec/chalk/pull/239 to run `chalk setup` as part of `setup.sh` when `connect: true` is provided