### PR TITLE
README: bump chalk version in example to 0.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For example:
 - name: Set up Chalk
   uses: crashappsec/setup-chalk-action@main
   with:
-    version: "0.3.0"
+    version: "0.3.4"
     connect: true
     load: "https://chalkdust.io/connect.c4m"
     token: ${{ secrets.CHALK_TOKEN }}


### PR DESCRIPTION
Release workflow run is [here](https://github.com/crashappsec/chalk-release/actions/runs/8330633435)