### PR TITLE
README: bump chalk version in example to 0.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For example:
 - name: Set up Chalk
   uses: crashappsec/setup-chalk-action@main
   with:
-    version: "0.3.4"
+    version: "0.3.5"
     connect: true
     load: "https://chalkdust.io/connect.c4m"
     token: ${{ secrets.CHALK_TOKEN }}


### PR DESCRIPTION
The chalk release runbook previously suggested that we could simply push to `main` for this. However, pushes to `main` in this repo do now require a PR due to a branch protection rule.