### PR TITLE
exporting GITHUB_TOKEN

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -137,3 +137,18 @@ runs:
           ${{ inputs.public_key != '' && format('--public-key={0}/chalk.pub', github.action_path) || '' }} \
           ${{ inputs.private_key != '' && format('--private-key={0}/chalk.key', github.action_path) || '' }} \
           ${{ runner.debug == '1' && '--debug' || '' }}
+
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+    # in some cases chalk needs to auth to GitHub API and it requires
+    # GITHUB_TOKEN env variable to be present
+    # Note that by default this env var is not accessible unless it is accessed
+    # by a secret - either 1) ${{ secrets.GITHUB_TOKEN }} or 2) ${{ github.token }}
+    # However as chalk can be invoked anywhere downstream of this action setting up chalk
+    # (e.g. by calling docker build from docker push action)
+    # we cannot guarantee that GITHUB_TOKEN is going to be accessible at that time
+    # and so we export it here to ensure chalk can succeed with its metadata collection
+    - name: Export GITHUB_TOKEN
+      if: runner.os == 'Linux' || runner.os == 'macOS'
+      shell: bash
+      run: |
+        [ -z "$GITHUB_TOKEN" ] && echo "GITHUB_TOKEN=${{ github.token }}" >> $GITHUB_ENV


### PR DESCRIPTION
as chalk github plugin attempts to talk to github API, it now requires access to GITHUB_TOKEN and so we automatically export it to ensure chalk can complete its metadata collection

this is required to make https://github.com/crashappsec/chalk/pull/303 work