### PR TITLE
running setup action relative to repo PWD

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Setup Chalk
         uses: ./
         with:
-          version: cecbf150e2fe0df7a813a8c4cb2923ba62b1fe40
           password: ${{ env.COSIGN_PASSWORD }}
           public_key: ${{ env.PUBLIC_KEY }}
           private_key: ${{ env.PRIVATE_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -125,13 +125,12 @@ runs:
     - name: Set up chalk
       if: runner.os == 'Linux' || runner.os == 'macOS'
       shell: bash
-      working-directory: ${{ github.action_path }}
       run: |
-        ./setup.sh \
+        ${{ github.action_path }}/setup.sh \
           --version='${{ inputs.version }}' \
           --load='${{ inputs.load }}' \
           --params='${{ inputs.params }}' \
-          --token="$(cat chalk.jwt 2> /dev/null)" \
+          --token="$(cat ${{ github.action_path }}/chalk.jwt 2> /dev/null)" \
           --prefix=$HOME/.chalk \
           ${{ inputs.connect == 'true' && '--setup' || '' }} \
           ${{ inputs.public_key != '' && format('--public-key={0}/chalk.pub', github.action_path) || '' }} \


### PR DESCRIPTION
otherwise cant load custom components where PATH should be relative to the repo triggering action, not action itself