### PR TITLE
loading custom profile vs generic connect.c4m

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ jobs:
 
 The following parameters can be provided to the action.
 
-| Name          | Type    | Description                                                                                                                                     |
-| ------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`     | String  | Version of chalk to install. By default latest version is installed. See [releases] for all available versions.                                 |
-| `load`        | String  | Chalk config(s) to load - comma or new-line delimited. Can be either paths to files or URLs.                                                    |
-| `params`      | String  | Chalk components params to load. Should be JSON array with all parameter values. JSON structure is the same as provided by `chalk dump params`. |
-| `connect`     | Boolean | Whether to automatically connect to https://crashoverride.run.                                                                                  |
-| `profile`     | String  | Key of the custom CrashOverride profile to load.                                                                                                |
-| `token`       | String  | CrashOverride API Token. Get your API token at [CrashOverride]                                                                                  |
-| `password`    | String  | Password for chalk signing key. Password is displayed as part of `chalk setup`.                                                                 |
-| `public_key`  | String  | Content of chalk signing public key). Copy from `chalk.pub` after `chalk setup`.                                                                |
-| `private_key` | String  | Content of chalk signing encrypted private key (with the provided password). Copy from `chalk.key` after `chalk setup`.                         |
+| Name          | Type    | Default   | Description                                                                                                                                     |
+| ------------- | ------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`     | String  | `latest`  | Version of chalk to install. By default latest version is installed. See [releases] for all available versions.                                 |
+| `load`        | String  |           | Chalk config(s) to load - comma or new-line delimited. Can be either paths to files or URLs.                                                    |
+| `params`      | String  |           | Chalk components params to load. Should be JSON array with all parameter values. JSON structure is the same as provided by `chalk dump params`. |
+| `connect`     | Boolean | `false`   | Whether to automatically connect to https://crashoverride.run.                                                                                  |
+| `profile`     | String  | `default` | Key of the custom CrashOverride profile to load.                                                                                                |
+| `token`       | String  |           | CrashOverride API Token. It is automatically fetched via OpenID connect if not provided when `connect=true`.                                    |
+| `password`    | String  |           | Password for chalk signing key. Password is displayed as part of `chalk setup`.                                                                 |
+| `public_key`  | String  |           | Content of chalk signing public key). Copy from `chalk.pub` after `chalk setup`.                                                                |
+| `private_key` | String  |           | Content of chalk signing encrypted private key (with the provided password). Copy from `chalk.key` after `chalk setup`.                         |
 
 For example:
 
@@ -57,6 +57,7 @@ For example:
   with:
     version: 0.4.11
     connect: true
+    profile: myprofile
     load: https://chalkdust.io/debug.c4m
     password: ${{ secrets.CHALK_PASSWORD }}
     public_key: ${{ secrets.CHALK_PUBLIC_KEY }}

--- a/README.md
+++ b/README.md
@@ -37,16 +37,17 @@ jobs:
 
 The following parameters can be provided to the action.
 
-| Name          | Type   | Default | Description                                                                                                                                     |
-| ------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`     | String |         | Version of chalk to install. By default latest version is installed. See [releases] for all available versions.                                 |
-| `load`        | String |         | Chalk config(s) to load - comma or new-line delimited. Can be either paths to files or URLs.                                                    |
-| `params`      | String |         | Chalk components params to load. Should be JSON array with all parameter values. JSON structure is the same as provided by `chalk dump params`. |
-| `connect`     | Bool   |         | Whether to automatically connect to https://crashoverride.run. If true, will load https://chalkdust.io/connect.c4m.                             |
-| `token`       | String |         | CrashOverride API Token. Get your API token at [CrashOverride]                                                                                  |
-| `password`    | String |         | Password for chalk signing key. Password is displayed as part of `chalk setup`.                                                                 |
-| `public_key`  | String |         | Content of chalk signing public key). Copy from `chalk.pub` after `chalk setup`.                                                                |
-| `private_key` | String |         | Content of chalk signing encrypted private key (with the provided password). Copy from `chalk.key` after `chalk setup`.                         |
+| Name          | Type    | Description                                                                                                                                     |
+| ------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`     | String  | Version of chalk to install. By default latest version is installed. See [releases] for all available versions.                                 |
+| `load`        | String  | Chalk config(s) to load - comma or new-line delimited. Can be either paths to files or URLs.                                                    |
+| `params`      | String  | Chalk components params to load. Should be JSON array with all parameter values. JSON structure is the same as provided by `chalk dump params`. |
+| `connect`     | Boolean | Whether to automatically connect to https://crashoverride.run.                                                                                  |
+| `profile`     | String  | Key of the custom CrashOverride profile to load.                                                                                                |
+| `token`       | String  | CrashOverride API Token. Get your API token at [CrashOverride]                                                                                  |
+| `password`    | String  | Password for chalk signing key. Password is displayed as part of `chalk setup`.                                                                 |
+| `public_key`  | String  | Content of chalk signing public key). Copy from `chalk.pub` after `chalk setup`.                                                                |
+| `private_key` | String  | Content of chalk signing encrypted private key (with the provided password). Copy from `chalk.key` after `chalk setup`.                         |
 
 For example:
 
@@ -54,10 +55,9 @@ For example:
 - name: Set up Chalk
   uses: crashappsec/setup-chalk-action@main
   with:
-    version: "0.4.11"
+    version: 0.4.11
     connect: true
-    load: "https://chalkdust.io/connect.c4m"
-    token: ${{ secrets.CHALK_TOKEN }}
+    load: https://chalkdust.io/debug.c4m
     password: ${{ secrets.CHALK_PASSWORD }}
     public_key: ${{ secrets.CHALK_PUBLIC_KEY }}
     private_key: ${{ secrets.CHALK_PRIVATE_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -28,10 +28,11 @@ inputs:
   profile:
     description: Key of the custom CrashOverride profile to load.
     required: false
+    default: profile
   token:
     description: |
       CrashOverride API Token.
-      Get your API token at CrashOverride: https://crashoverride.run
+      It is automatically fetched via OpenID connect if not provided when `connect=true`.                                    |
     required: false
   password:
     description: |

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,7 @@ inputs:
       By default latest version is installed.
       See https://crashoverride.com/releases for all available versions.
     required: false
+    default: latest
   load:
     description: |
       Chalk config(s) to load - comma or new-line delimited.
@@ -23,7 +24,9 @@ inputs:
   connect:
     description: |
       Whether to automatically connect to https://crashoverride.run.
-      If true, will load https://chalkdust.io/connect.c4m.
+    required: false
+  profile:
+    description: Key of the custom CrashOverride profile to load.
     required: false
   token:
     description: |
@@ -49,6 +52,20 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Hide provided JWT token
+      if: inputs.token != ''
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        echo "::add-mask::${{ inputs.token }}"
+
+    - name: Hide provided password
+      if: inputs.password != ''
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        echo "::add-mask::${{ inputs.password }}"
+
     # https://docs.sigstore.dev/system_config/installation/
     - name: Install cosign
       if: runner.os == 'Linux' || runner.os == 'macOS'
@@ -84,44 +101,6 @@ runs:
       run: |
         printenv CHALK_PRIVATE_KEY > chalk.key
 
-    - name: Save provided JWT token
-      if: (runner.os == 'Linux' || runner.os == 'macOS') && inputs.token != ''
-      shell: bash
-      working-directory: ${{ github.action_path }}
-      run: |
-        echo "${{ inputs.token }}" > chalk.jwt
-
-    - name: Get JWT by using GitHub OpenId Connect
-      if: (runner.os == 'Linux' || runner.os == 'macOS') && inputs.connect != '' && inputs.connect != 'false' && inputs.token == ''
-      shell: bash
-      working-directory: ${{ github.action_path }}
-      run: |
-        curl \
-          --fail \
-          --silent \
-          --header "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-          "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://crashoverride.run" \
-          > github.jwt || (
-          echo "Cannot generate GitHub OpenId Connect JWT Token."
-          echo "Please make sure workflow/job has 'id-token: write' permission."
-          echo "See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings"
-          exit 1
-        )
-        curl \
-          --fail \
-          --silent \
-          --request POST \
-          --data-binary @github.jwt \
-          --header 'Content-Type: application/json' \
-          https://chalk.crashoverride.run/v0.1/openid-connect/github \
-          | jq -r '.jwt' \
-          > chalk.jwt || (
-          echo "Could not retrieve Chalk JWT token."
-          echo "Please make sure GitHub integration is configured in your CrashOverride workspace."
-          exit 1
-        )
-        echo "::add-mask::$(cat chalk.jwt)"
-
     - name: Set up chalk
       if: runner.os == 'Linux' || runner.os == 'macOS'
       shell: bash
@@ -130,9 +109,10 @@ runs:
           --version='${{ inputs.version }}' \
           --load='${{ inputs.load }}' \
           --params='${{ inputs.params }}' \
-          --token="$(cat ${{ github.action_path }}/chalk.jwt 2> /dev/null)" \
+          --token='${{ inputs.token }}' \
           --prefix=$HOME/.chalk \
-          ${{ inputs.connect == 'true' && '--setup' || '' }} \
+          --profile='${{ inputs.profile }}' \
+          ${{ inputs.connect == 'true' && '--connect' || '' }} \
           ${{ inputs.public_key != '' && format('--public-key={0}/chalk.pub', github.action_path) || '' }} \
           ${{ inputs.private_key != '' && format('--private-key={0}/chalk.key', github.action_path) || '' }} \
           ${{ runner.debug == '1' && '--debug' || '' }}

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
   profile:
     description: Key of the custom CrashOverride profile to load.
     required: false
-    default: profile
+    default: default
   token:
     description: |
       CrashOverride API Token.

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
   token:
     description: |
       CrashOverride API Token.
-      It is automatically fetched via OpenID connect if not provided when `connect=true`.                                    |
+      It is automatically fetched via OpenID connect if not provided when `connect=true`.
     required: false
   password:
     description: |

--- a/setup.sh
+++ b/setup.sh
@@ -276,13 +276,13 @@ download_chalk() {
     chalk_tmp=$TMP/$(chalk_version_name)
 
     if [ -n "$copy_from" ]; then
-        info Copying existing chalk from "$copy_from"
+        info Copying existing Chalk from "$copy_from"
         cp "$copy_from" "$TMP/$name"
         return
     fi
 
     url=$URL_PREFIX/$(chalk_folder)/$name
-    info Downloading chalk from "$url"
+    info Downloading Chalk from "$url"
     rm -f "$TMP/$name" "$TMP/$name.sha256"
     wget --quiet --directory-prefix=$TMP "$url" "$url.sha256" || (
         fatal Could not download "$name". Are you sure this is a valid version?
@@ -299,17 +299,17 @@ download_chalk() {
             cat "$chalk_tmp.sha256" > /dev/stderr
             error Downloaded checksum:
             $SHA256 "$chalk_tmp" > /dev/stderr
-            fatal Oh no. Checksum validation failed. Exiting as chalk binary might of been tampered with
+            fatal Oh no. Checksum validation failed. Exiting as Chalk binary might of been tampered with
         )
     )
 }
 
-# validate downloaded chalk can run on the system
+# validate downloaded Chalk can run on the system
 # and then install it to $chalk_path which should be on PATH
 install_chalk() {
-    info Checking chalk version
+    info Checking Chalk version
     chalk_path=$chalk_tmp chalk version
-    info Installing chalk to "$chalk_path"
+    info Installing Chalk to "$chalk_path"
     $SUDO mkdir -p "$(dirname "$chalk_path")"
     $SUDO cp "$chalk_tmp" "$chalk_path"
     $SUDO chmod +xr "$chalk_tmp"
@@ -332,7 +332,7 @@ download_platform() {
         return 1
     fi
     arch_path=~/.local/chalk/bin/${os}/${arch}/chalk
-    info Copying chalk "$os/$arch" to "$arch_path"
+    info Copying Chalk "$os/$arch" to "$arch_path"
     mkdir -p "$(dirname "$arch_path")"
     cp "$chalk_tmp" "$arch_path"
     chmod +xr "$arch_path"
@@ -341,12 +341,12 @@ download_platform() {
 normalize_cosign() {
     if is_installed cosign; then
         # TODO fix in src/configs/attestation.c4m
-        info Copying cosign to /tmp for chalk
+        info Copying cosign to /tmp for Chalk
         cp "$(which cosign)" /tmp/cosign
     fi
 }
 
-# load custom chalk config
+# load custom Chalk config
 load_config() {
     to_load=$1
     if [ "$params" = "-" ]; then
@@ -362,7 +362,7 @@ load_config() {
     fi
 }
 
-# add lines to chalk config
+# add lines to Chalk config
 add_lines_to_chalk() {
     name=$1
     shift
@@ -378,7 +378,7 @@ add_lines_to_chalk() {
     fi
 }
 
-# add necessary configs to wrap command with chalk
+# add necessary configs to wrap command with Chalk
 add_cmd_exe_to_config() {
     cmd=$1
     path=$2
@@ -389,7 +389,7 @@ add_cmd_exe_to_config() {
         "${cmd}_exe = \"$folder\""
 }
 
-# wrap given command with chalk
+# wrap given command with Chalk
 wrap_cmd() {
     cmd=$1
 
@@ -406,7 +406,7 @@ wrap_cmd() {
         return 0
     fi
 
-    info Wrapping "$existing_path" command with chalk
+    info Wrapping "$existing_path" command with Chalk
 
     $SUDO mkdir -p "$(dirname "$chalkless_path")"
     if am_owner "$existing_path"; then
@@ -419,15 +419,15 @@ wrap_cmd() {
         $SUDO cp "$existing_path" "$chalkless_path"
     fi
 
-    # create temporary chalk copy so that we can adjust its configuration
+    # create temporary Chalk copy so that we can adjust its configuration
     # to be able to find the moved binary in the chalkless location
-    info Wrapping "$chalked_path" with chalk
+    info Wrapping "$chalked_path" with Chalk
     tmp=$(mktemp -t chalk.XXXXXX)
     $SUDO cp "$chalk_path" "$tmp"
     chalk_path=$tmp add_cmd_exe_to_config "$cmd" "$chalkless_path"
     $SUDO rm "$chalked_path" 2> /dev/null || true
     $SUDO cp "$tmp" "$chalked_path"
-    info Using "$chalked_path" will automatically use chalk now
+    info Using "$chalked_path" will automatically use Chalk now
 }
 
 copy_keys() {
@@ -437,7 +437,7 @@ copy_keys() {
 
 help() {
     cat << EOF
-Setup chalk:
+Setup Chalk:
 
 * Downloads binary
 * Verifies checksum
@@ -452,7 +452,7 @@ Args:
 --version=*         Chalk version/commit to download.
                     By default latest version is used.
 --load=*            Comma/newline delimited paths/URLs
-                    of chalk components to load.
+                    of Chalk components to load.
 --params=*          JSON of component params to load.
                     Can be "-" to read params from stdin.
 --connect           Automatically connect to CrashOverride
@@ -461,30 +461,30 @@ Args:
 --profile=*         Name of the custom CrashOverride
                     to load. Default is 'default'.
 --token=*           CrashOverride JWT token to load.
---prefix=*          Where to install chalk and related
+--prefix=*          Where to install Chalk and related
                     binaries. Default is ${prefix}.
---chalk-path=*      Exact path where to install chalk.
+--chalk-path=*      Exact path where to install Chalk.
                     Default is $(get_chalk_path).
 --no-wrap=*         Do not wrap supported binaries.
 --debug             Enable debug mode. This enables trace
-                    logs for installed chalk and will
+                    logs for installed Chalk and will
                     run setup script in verbose mode.
---[no-]overwrite    Whether to overwrite chalk binary
+--[no-]overwrite    Whether to overwrite Chalk binary
                     if $(get_chalk_path) already exists.
                     Default is ${overwrite}.
---timeout=*         Timeout for chalk commands.
+--timeout=*         Timeout for Chalk commands.
                     Default is ${timeout}.
---platforms=*       Download additional chalk platforms to
+--platforms=*       Download additional Chalk platforms to
                     ~/.local/chalk/bin/{os}/{arch}/chalk.
 --public-key=*      Path to signing public key.
 --private-key=*     Path to signing private key encrypted with
                     CHALK_PASSWORD env var.
---setup             Run chalk setup. Also setup automatically runs
+--setup             Run Chalk setup. Also setup automatically runs
                     if --public-key and --private-key are provided.
 
 Args for debugging:
 
---copy-from=*       Instead of downloading chalk binary
+--copy-from=*       Instead of downloading Chalk binary
                     copy it from this path instead.
 EOF
     exit "${1:-0}"
@@ -614,21 +614,21 @@ for i in $(echo "$load" | tr "," "\n" | tr " " "\n"); do
     if [ -z "$i" ]; then
         continue
     fi
-    info Loading custom chalk config from "$i"
+    info Loading custom Chalk config from "$i"
     load_config "$i"
 done
 
 if [ -n "$debug" ]; then
-    info Debug mode is enabled. Changing default chalk log level to trace
+    info Debug mode is enabled. Changing default Chalk log level to trace
     params='' load_config https://chalkdust.io/debug.c4m
 fi
 
 if [ -n "$password" ] && [ -f "$public_key" ] && [ -f "$private_key" ]; then
-    info "Loading signing keys into chalk"
+    info "Loading signing keys into Chalk"
     copy_keys
     chalk setup
 elif [ -n "$setup" ] || [ -n "$token" ]; then
-    info "Setting up chalk attestation"
+    info "Setting up Chalk attestation"
     chalk setup
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -494,13 +494,13 @@ Args:
 
 -h / --help         Show this message
 --version=*         Chalk version/commit to download.
-                    By default latest version is used.
+                    Default is '${version}'.
 --load=*            Comma/newline delimited paths/URLs
                     of Chalk components to load.
 --params=*          JSON of component params to load.
                     Can be "-" to read params from stdin.
 --profile=*         Name of the custom CrashOverride profile
-                    to load. Default is 'default'.
+                    to load. Default is '${profile}'.
 --connect           Automatically connect to CrashOverride
                     via OpenID Connect OIDC.
                     Currently supports:
@@ -513,20 +513,22 @@ Args:
 --token=*           CrashOverride API token when OpenID Connect
                     cannot be used.
 --prefix=*          Where to install Chalk and related
-                    binaries. Default is ${prefix}.
+                    binaries. Default is '${prefix}'.
 --chalk-path=*      Exact path where to install Chalk.
-                    Default is $(get_chalk_path).
+                    Default is '$(get_chalk_path)'.
 --no-wrap=*         Do not wrap supported binaries.
 --debug             Enable debug mode. This enables trace
                     logs for installed Chalk and will
                     run setup script in verbose mode.
 --[no-]overwrite    Whether to overwrite Chalk binary
-                    if $(get_chalk_path) already exists.
-                    Default is ${overwrite}.
---timeout=*         Timeout for Chalk commands.
-                    Default is ${timeout}.
+                    if '$(get_chalk_path)' already exists.
+                    Default is '${overwrite}'.
+--timeout=*         Timeout for Chalk commands (in seconds).
+                    Default is '${timeout}.
 --platforms=*       Download additional Chalk platforms to
-                    ~/.local/chalk/bin/{os}/{arch}/chalk.
+                    '~/.local/chalk/bin/{os}/{arch}/chalk'.
+                    Same notation as docker platform syntax
+                    of '{os}/{arch}'.
 --public-key=*      Path to signing public key.
 --private-key=*     Path to signing private key encrypted with
                     CHALK_PASSWORD env var.

--- a/setup.sh
+++ b/setup.sh
@@ -4,8 +4,8 @@ set -eu
 
 # URL_PREFIX=https://crashoverride.com/dl
 URL_PREFIX=https://dl.crashoverride.run
-OPENID_CONNECT=https://chalk-test.crashoverride.run/v0.1/openid-connect/github
-PROFILE=https://chalk-test.crashoverride.run/v0.1/profile
+OPENID_CONNECT=https://chalk.crashoverride.run/v0.1/openid-connect/github
+PROFILE=https://chalk.crashoverride.run/v0.1/profile
 SHA256=sha256sum
 SUDO=sudo
 TMP=/tmp

--- a/setup.sh
+++ b/setup.sh
@@ -499,14 +499,19 @@ Args:
                     of Chalk components to load.
 --params=*          JSON of component params to load.
                     Can be "-" to read params from stdin.
---connect           Automatically connect to CrashOverride
-                    via OpenID Connect
-                    (supports only some CI systems).
---profile=*         Name of the custom CrashOverride
+--profile=*         Name of the custom CrashOverride profile
                     to load. Default is 'default'.
---token=*           CrashOverride API JWT token.
---oidc=*            OpenID Connect OIDC token to retrieve
-                    CrashOverride JWT token.
+--connect           Automatically connect to CrashOverride
+                    via OpenID Connect OIDC.
+                    Currently supports:
+                    * GitHub (requires id-token: write permission)
+--oidc=*            When --connect cannot automatically generate
+                    OpenID Connect token, OIDC token can be passed
+                    directly via a parameter or CHALK_OIDC env var.
+                    Currently supports:
+                    * GitLab (requires using id_tokens)
+--token=*           CrashOverride API token when OpenID Connect
+                    cannot be used.
 --prefix=*          Where to install Chalk and related
                     binaries. Default is ${prefix}.
 --chalk-path=*      Exact path where to install Chalk.


### PR DESCRIPTION
currently the action was hard coding the use of `connect.c4m` which allowed to connect Chalk to CrashOverride.

This change allows to connect Chalk to a custom profile as configured in CrashOverride UI. The rough flow is:

* CI system generates OIDC token
* the token is sent to CrashOverride to lookup which org the SCM is installed in
* CrashOverride mints new JWT for the found org
* new JWT is used to lookup chalk profile/parameters to be loaded into chalk
* downloaded profile/parameters embed lower-permission JWT scoped to the action the component is configured to do. For example sending reports JWT doesnt have permission to access attestation keys.

This allows friction-free UX across multiple CI systems with fully custom chalk profiles. Currently supports:

* GitHub
* GitLab

For CI systems which do not support this feature the `--token` can be manually passed which will point chalk to the CrashOverride org without OIDC tokens. 