### PR TITLE
cosign and container workflow fixes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,8 +108,9 @@ runs:
     - name: Set up chalk
       if: runner.os == 'Linux' || runner.os == 'macOS'
       shell: sh
+      working-directory: ${{ github.action_path }}
       run: |
-        ${{ github.action_path }}/setup.sh \
+        ./setup.sh \
           --version='${{ inputs.version }}' \
           --load='${{ inputs.load }}' \
           --params='${{ inputs.params }}' \
@@ -117,8 +118,8 @@ runs:
           --prefix=$HOME/.chalk \
           --profile='${{ inputs.profile }}' \
           ${{ inputs.connect == 'true' && '--connect' || '' }} \
-          ${{ inputs.public_key != '' && format('--public-key={0}/chalk.pub', github.action_path) || '' }} \
-          ${{ inputs.private_key != '' && format('--private-key={0}/chalk.key', github.action_path) || '' }} \
+          ${{ inputs.public_key != '' && format('--public-key=./chalk.pub') || '' }} \
+          ${{ inputs.private_key != '' && format('--private-key=./chalk.key') || '' }} \
           ${{ runner.debug == '1' && '--debug' || '' }}
 
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

--- a/action.yml
+++ b/action.yml
@@ -115,8 +115,8 @@ runs:
           --load='${{ inputs.load }}' \
           --params='${{ inputs.params }}' \
           --token='${{ inputs.token }}' \
-          --prefix=$HOME/.chalk \
           --profile='${{ inputs.profile }}' \
+          --prefix=${{ job.container.id == '' && '$HOME/.chalk' || '' }} \
           ${{ inputs.connect == 'true' && '--connect' || '' }} \
           ${{ inputs.public_key != '' && format('--public-key=./chalk.pub') || '' }} \
           ${{ inputs.private_key != '' && format('--private-key=./chalk.key') || '' }} \

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,9 @@ runs:
     - name: Install cosign
       if: runner.os == 'Linux' || runner.os == 'macOS'
       uses: sigstore/cosign-installer@main
+      # most likely bash is missing
+      # https://github.com/sigstore/cosign-installer/issues/190
+      continue-on-error: true
 
     - name: Add Chalk to PATH
       if: runner.os == 'Linux' || runner.os == 'macOS'

--- a/action.yml
+++ b/action.yml
@@ -118,8 +118,8 @@ runs:
           --profile='${{ inputs.profile }}' \
           --prefix=${{ job.container.id == '' && '$HOME/.chalk' || '' }} \
           ${{ inputs.connect == 'true' && '--connect' || '' }} \
-          ${{ inputs.public_key != '' && format('--public-key=./chalk.pub') || '' }} \
-          ${{ inputs.private_key != '' && format('--private-key=./chalk.key') || '' }} \
+          ${{ inputs.public_key != '' && '--public-key=./chalk.pub' || '' }} \
+          ${{ inputs.private_key != '' && '--private-key=./chalk.key' || '' }} \
           ${{ runner.debug == '1' && '--debug' || '' }}
 
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

--- a/setup.sh
+++ b/setup.sh
@@ -647,9 +647,12 @@ for arg; do
             params=${arg##*=}
             ;;
         --prefix=*)
-            prefix=${arg##*=}
-            prefix=$(echo "$prefix" | sed "s#~#$HOME#" | sed 's/bin$//')
-            prefix=$(realpath "$prefix")
+            p=${arg##*=}
+            if [ -n "$p" ]; then
+                prefix=${arg##*=}
+                prefix=$(echo "$prefix" | sed "s#~#$HOME#" | sed 's/bin$//')
+                prefix=$(realpath "$prefix")
+            fi
             ;;
         --chalk-path=*)
             chalk_path=${arg##*=}
@@ -702,7 +705,7 @@ fi
 chalk_path=$(get_chalk_path)
 chalk_tmp=
 
-if am_owner "$prefix"; then
+if am_owner "$prefix" || [ "$(id -u)" = "0" ]; then
     SUDO=
 else
     if [ -z "$SUDO" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -649,7 +649,7 @@ for arg; do
         --prefix=*)
             p=${arg##*=}
             if [ -n "$p" ]; then
-                prefix=${arg##*=}
+                prefix=$p
                 prefix=$(echo "$prefix" | sed "s#~#$HOME#" | sed 's/bin$//')
                 prefix=$(realpath "$prefix")
             fi


### PR DESCRIPTION
Github workflow steps can be executed in a container in which case setup chalk action will break with `setup.sh` not found. `github.action_path` is correct however outside of `run` context so switching to working-directory and then using relative paths inside the `run` block.

In addition `cosign` currently depends on `bash` which might not be present in the container so making that step optional so that it doesnt fail the action overall