### PR TITLE
feat: lookup chalk version from chalk profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ jobs:
 
 The following parameters can be provided to the action.
 
-| Name          | Type    | Default   | Description                                                                                                                                     |
-| ------------- | ------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`     | String  | `latest`  | Version of chalk to install. By default latest version is installed. See [releases] for all available versions.                                 |
-| `load`        | String  |           | Chalk config(s) to load - comma or new-line delimited. Can be either paths to files or URLs.                                                    |
-| `params`      | String  |           | Chalk components params to load. Should be JSON array with all parameter values. JSON structure is the same as provided by `chalk dump params`. |
-| `connect`     | Boolean | `false`   | Whether to automatically connect to https://crashoverride.run.                                                                                  |
-| `profile`     | String  | `default` | Key of the custom CrashOverride profile to load.                                                                                                |
-| `token`       | String  |           | CrashOverride API Token. It is automatically fetched via OpenID connect if not provided when `connect=true`.                                    |
-| `password`    | String  |           | Password for chalk signing key. Password is displayed as part of `chalk setup`.                                                                 |
-| `public_key`  | String  |           | Content of chalk signing public key). Copy from `chalk.pub` after `chalk setup`.                                                                |
-| `private_key` | String  |           | Content of chalk signing encrypted private key (with the provided password). Copy from `chalk.key` after `chalk setup`.                         |
+| Name          | Type    | Default   | Description                                                                                                                                                                                                       |
+| ------------- | ------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`     | String  | `latest`  | Version of chalk to install. By default latest version is installed. See [releases] for all available versions. When `connect` is true, if version is left empty, its looked up from CrashOverride Chalk profile. |
+| `load`        | String  |           | Chalk config(s) to load - comma or new-line delimited. Can be either paths to files or URLs.                                                                                                                      |
+| `params`      | String  |           | Chalk components params to load. Should be JSON array with all parameter values. JSON structure is the same as provided by `chalk dump params`.                                                                   |
+| `connect`     | Boolean | `false`   | Whether to automatically connect to https://crashoverride.run.                                                                                                                                                    |
+| `profile`     | String  | `default` | Key of the custom CrashOverride profile to load.                                                                                                                                                                  |
+| `token`       | String  |           | CrashOverride API Token. It is automatically fetched via OpenID connect if not provided when `connect=true`.                                                                                                      |
+| `password`    | String  |           | Password for chalk signing key. Password is displayed as part of `chalk setup`.                                                                                                                                   |
+| `public_key`  | String  |           | Content of chalk signing public key). Copy from `chalk.pub` after `chalk setup`.                                                                                                                                  |
+| `private_key` | String  |           | Content of chalk signing encrypted private key (with the provided password). Copy from `chalk.key` after `chalk setup`.                                                                                           |
 
 For example:
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
       By default latest version is installed.
       See https://crashoverride.com/releases for all available versions.
     required: false
-    default: latest
+    default: ""
   load:
     description: |
       Chalk config(s) to load - comma or new-line delimited.


### PR DESCRIPTION
This allows to leave the version non-specified in the setup-chalk-action but still pin version from chalk profile:

<img width="663" alt="image" src="https://github.com/user-attachments/assets/a7dba2bc-47cc-430a-acdd-bb2121e0f832" />

although profile can still use "latest" version which will then dynamically query latest version:

<img width="663" alt="image" src="https://github.com/user-attachments/assets/9356ef45-74ab-4476-b23c-b7202a80f79f" />
