### PR TITLE
fix: ignore exit code 1 when GITHUB_TOKEN is not present

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
       if: env.__CHALK_ALREADY_SETUP__ == '' && (runner.os == 'Linux' || runner.os == 'macOS')
       shell: sh
       run: |
-        [ -z "$GITHUB_TOKEN" ] && echo "GITHUB_TOKEN=${{ github.token }}" >> $GITHUB_ENV
+        [ -z "$GITHUB_TOKEN" ] && echo "GITHUB_TOKEN=${{ github.token }}" >> $GITHUB_ENV || true
 
     - name: Set chalk was already setup to avoid duplicate setups
       if: env.__CHALK_ALREADY_SETUP__ == '' && (runner.os == 'Linux' || runner.os == 'macOS')


### PR DESCRIPTION
github runs shell script with -e and therefore all commands should succeed unless encounter an error

otherwise GitHub is showing:

```
Error: Process completed with exit code 1.
```