### PR TITLE
self-hosted runner compatibility

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -8,43 +8,37 @@ permissions:
 
 env:
   COSIGN_PASSWORD: 6EHvWD1BUk0yWdvm-GGNxA==
+  PUBLIC_KEY: |
+    -----BEGIN PUBLIC KEY-----
+    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfH1ovT0O5dYpileubczT0MQsNsDu
+    UhQ1aC2F3S5t48q6bMATGm9IV7Id5/NkUWHjq5mgLX8QhygoSAab+FzEqA==
+    -----END PUBLIC KEY-----
+  PRIVATE_KEY: |
+    -----BEGIN ENCRYPTED SIGSTORE PRIVATE KEY-----
+    eyJrZGYiOnsibmFtZSI6InNjcnlwdCIsInBhcmFtcyI6eyJOIjo2NTUzNiwiciI6
+    OCwicCI6MX0sInNhbHQiOiJkK0JiMUVzVzhWTXVrekZFRmh0QjJZWGZyMm00ckw2
+    MjZGMXc0QWlKVnU0PSJ9LCJjaXBoZXIiOnsibmFtZSI6Im5hY2wvc2VjcmV0Ym94
+    Iiwibm9uY2UiOiJGTFNScFNxRDU1UzhyZVc2ZmxuV0JncDFDay9zUFd0QyJ9LCJj
+    aXBoZXJ0ZXh0IjoiaUNXbHN4WXFrY0Mvb3JmaVRhRlgwdmpZUDdldDFYSmNlWG5G
+    SVZNS0RPMFhsaG13WnkzSWh6VWpYREgvdm1XMFNCMVBkV2lOZDNWZU56VVlkNzZR
+    L3JjWmVsRHQyMlh6ZFJsTnpQeXVudDMrcU40aUcyOFc5M2Z0OFZ4b1I2UkZoVUMy
+    Y0dNbGMxTFJiMjk4ZXA2bU50WFo0aUxGMm5MYWg1dy8xbTVNeTV5WTZqd2ZHd09z
+    MHYzME1uNUhGWDArTm9VQjVzd2U5dUxPZlE9PSJ9
+    -----END ENCRYPTED SIGSTORE PRIVATE KEY-----
 
 jobs:
-  ubuntu:
-    runs-on: ubuntu-latest
+  host:
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+          # - runner: self-hosted
 
-    outputs:
-      PUBLIC_KEY: ${{ steps.key.outputs.PUBLIC_KEY }}
-      PRIVATE_KEY: ${{ steps.key.outputs.PRIVATE_KEY }}
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@main
-
-      - name: Generate key
-        run: |
-          cosign \
-            generate-key-pair \
-            --output-key-prefix chalk
-          {
-            echo 'PUBLIC_KEY<<EOF'
-            cat chalk.pub
-            echo EOF
-          } >> "$GITHUB_ENV"
-          {
-            echo 'PRIVATE_KEY<<EOF'
-            cat chalk.key
-            echo EOF
-          } >> "$GITHUB_ENV"
-
-      - name: Export key
-        id: key
-        run: |
-          printf "PUBLIC_KEY<<EOF\n%s\nEOF\n" "${{ env.PUBLIC_KEY }}" >> "$GITHUB_OUTPUT"
-          printf "PRIVATE_KEY<<EOF\n%s\nEOF\n" "${{ env.PRIVATE_KEY }}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Chalk
         uses: ./
@@ -59,22 +53,24 @@ jobs:
         run: |
           echo 'log_level: "trace"' | sudo tee /etc/chalk.conf
           set -x
+          id
           which chalk
           which docker
-          strings $(which chalk) | tail -n 18 | head -n1 | jq
-          strings $(which docker) | tail -n 18 | head -n1 | jq
+          strings $(which chalk) | tail -n 30 | grep dadfedabbadabbed | jq
+          strings $(which docker) | tail -n 30 | grep dadfedabbadabbed  | jq
           chalk version
           docker version
 
   container:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+
+    runs-on: ${{ matrix.runner }}
 
     container:
       image: docker
-
-    # docker containeris alpine-based hence cannot install cosign here directly
-    # as it requires bash
-    needs: [ubuntu] # for cosign
 
     steps:
       - name: Checkout
@@ -88,8 +84,8 @@ jobs:
         uses: ./
         with:
           password: ${{ env.COSIGN_PASSWORD }}
-          public_key: ${{ needs.ubuntu.outputs.PUBLIC_KEY }}
-          private_key: ${{ needs.ubuntu.outputs.PRIVATE_KEY }}
+          public_key: ${{ env.PUBLIC_KEY }}
+          private_key: ${{ env.PRIVATE_KEY }}
           load: |
             .github/config.c4m
 
@@ -97,9 +93,10 @@ jobs:
         run: |
           echo 'log_level: "trace"' | tee /etc/chalk.conf
           set -x
+          id
           which chalk
           which docker
-          strings $(which chalk) | tail -n 18 | head -n1 | jq
-          strings $(which docker) | tail -n 18 | head -n1 | jq
+          strings $(which chalk) | tail -n 30 | grep dadfedabbadabbed | jq
+          strings $(which docker) | tail -n 30 | grep dadfedabbadabbed  | jq
           chalk version
           docker version

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tags
 .envrc
 *.pub
 *.key
+node_modules

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,31 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-yaml
+      - id: check-json
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
 
   - repo: https://github.com/maxwinterstein/shfmt-py
-    rev: v3.7.0.1
+    rev: v3.12.0.1
     hooks:
       - id: shfmt
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.6
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
+
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.6.2
+    hooks:
+      - id: prettier
+
+  - repo: https://github.com/crashappsec/pre-commit-sync
+    rev: 0.1.0.a3
+    hooks:
+      - id: pre-commit-sync

--- a/action.yml
+++ b/action.yml
@@ -63,11 +63,21 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set temporary folder for chalk to place tmp files in
+      if: env.__CHALK_ALREADY_SETUP__ == '' && (runner.os == 'Linux' || runner.os == 'macOS')
+      shell: sh
+      env:
+        ACTION: ${{ github.action_repository }}
+      run: |
+        tmp="$RUNNER_TEMP/${ACTION:-chalk}/$GITHUB_RUN_ID"
+        mkdir -p "$tmp"
+        echo "CHALK_TMP=$(mktemp -d -p "$tmp")" >> $GITHUB_ENV
+
     - name: Set chalk prefix for non-container builds
       if: env.__CHALK_ALREADY_SETUP__ == '' && (runner.os == 'Linux' || runner.os == 'macOS') && job.container.id == ''
       shell: sh
       run: |
-        echo "CHALK_PREFIX=$HOME/.chalk/" >> $GITHUB_ENV
+        echo "CHALK_PREFIX=$CHALK_TMP" >> $GITHUB_ENV
 
     - name: Set chalk prefix for container builds
       if: env.__CHALK_ALREADY_SETUP__ == '' && (runner.os == 'Linux' || runner.os == 'macOS') && job.container.id != ''
@@ -84,14 +94,12 @@ runs:
     - name: Hide provided JWT token
       if: env.__CHALK_ALREADY_SETUP__ == '' && inputs.token != ''
       shell: sh
-      working-directory: ${{ github.action_path }}
       run: |
         echo "::add-mask::${{ inputs.token }}"
 
     - name: Hide provided password
       if: env.__CHALK_ALREADY_SETUP__ == '' && inputs.password != ''
       shell: sh
-      working-directory: ${{ github.action_path }}
       run: |
         echo "::add-mask::${{ inputs.password }}"
 
@@ -112,20 +120,18 @@ runs:
     - name: Save Public Key
       if: env.__CHALK_ALREADY_SETUP__ == '' && (runner.os == 'Linux' || runner.os == 'macOS') && inputs.public_key != ''
       shell: sh
-      working-directory: ${{ github.action_path }}
       env:
         CHALK_PUBLIC_KEY: "${{ inputs.public_key }}"
       run: |
-        printenv CHALK_PUBLIC_KEY > chalk.pub
+        printenv CHALK_PUBLIC_KEY > "$CHALK_TMP/chalk.pub"
 
     - name: Save Private Key
       if: env.__CHALK_ALREADY_SETUP__ == '' && (runner.os == 'Linux' || runner.os == 'macOS') && inputs.private_key != ''
       shell: sh
-      working-directory: ${{ github.action_path }}
       env:
         CHALK_PRIVATE_KEY: "${{ inputs.private_key }}"
       run: |
-        printenv CHALK_PRIVATE_KEY > chalk.key
+        printenv CHALK_PRIVATE_KEY > "$CHALK_TMP/chalk.key"
 
     - name: Determine Action Path
       id: action_path
@@ -134,6 +140,15 @@ runs:
       working-directory: ${{ github.action_path }}
       run: |
         echo "value=$(pwd)" >> $GITHUB_OUTPUT
+
+    # for self-hosted runners home folder is not cleaned up in-between jobs
+    # hence there could be previously-downloaded chalk binaries in there
+    # which should be cleaned up
+    - name: Cleanup previously downloaded chalk binaries
+      if: env.__CHALK_ALREADY_SETUP__ == '' && (runner.os == 'Linux' || runner.os == 'macOS') && runner.environment == 'self-hosted'
+      shell: sh
+      run: |
+        rm -rf ~/.local/chalk/bin || true
 
     - name: Set up chalk
       id: chalk
@@ -148,9 +163,25 @@ runs:
           --token='${{ inputs.token }}' \
           --profile='${{ inputs.profile }}' \
           ${{ inputs.connect == 'true' && '--connect' || '' }} \
-          ${{ inputs.public_key != '' && format('--public-key={0}/chalk.pub', steps.action_path.outputs.value) || '' }} \
-          ${{ inputs.private_key != '' && format('--private-key={0}/chalk.key', steps.action_path.outputs.value) || '' }} \
+          ${{ inputs.public_key != '' && format('--public-key={0}/chalk.pub', env.CHALK_TMP) || '' }} \
+          ${{ inputs.private_key != '' && format('--private-key={0}/chalk.key', env.CHALK_TMP) || '' }} \
           ${{ runner.debug == '1' && '--debug' || '' }}
+
+    - name: Cleanup Public Key
+      if: env.__CHALK_ALREADY_SETUP__ == '' && (runner.os == 'Linux' || runner.os == 'macOS') && inputs.public_key != ''
+      shell: sh
+      env:
+        CHALK_PUBLIC_KEY: "${{ inputs.public_key }}"
+      run: |
+        rm "$CHALK_TMP/chalk.pub"
+
+    - name: Cleanup Private Key
+      if: env.__CHALK_ALREADY_SETUP__ == '' && (runner.os == 'Linux' || runner.os == 'macOS') && inputs.private_key != ''
+      shell: sh
+      env:
+        CHALK_PRIVATE_KEY: "${{ inputs.private_key }}"
+      run: |
+        rm "$CHALK_TMP/chalk.key"
 
     # github doesnt support using inputs for the action version
     # so we template inline action


### PR DESCRIPTION
previously chalk was being installed in a single folder `~/.chalk` which would not be automatically cleaned up at the end of the job hence any subsequent executions on the same self-hosted runner would run into issues as it will fail to overwrite existing installation.

As each job can configure chalk differently, moved the installation into `RUNNER_TEMP` under a unique temporary folder name to ensure no conflicts occur between job executions

This should also handle the case if the same self-hosted runner VM is configured to use the same workspace folder for multiple runner processes hence unique folder name should avoid any conflicts.

Also doing some tidy-work with the public keys if provided as well as removing an option to download chalk for multiple-platforms as that would download chalk into `~` which is not ideal for self-hosted runners.

Similarly also cleaning up previously downloaded chalk binaries as could be downloaded by other job executions