### PR TITLE
fix: remove some unnecessary subshells

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -590,7 +590,7 @@ wrap_cmd() {
         info Hardlinking "$chalkless_path" to "$existing_path"
         $SUDO ln "$existing_path" "$chalkless_path"
     else
-        info Copying "$chalkless_path" to "$existing_path"
+        info Copying "$existing_path" to "$chalkless_path"
         $SUDO cp "$existing_path" "$chalkless_path"
     fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -160,7 +160,6 @@ CHALKAPI_HOST=
 if [ -n "${__CHALK_TESTING__:-}" ]; then
     warn Beware - chalk is now using test environment which is meant for internal chalk testing only.
     ENTITLEMENTS_HOST=https://entitlements-test.crashoverride.run
-    CHALKAPI_HOST=https://chalk-test.crashoverride.run
 fi
 
 first_owner() {


### PR DESCRIPTION
to compute the chalk api url, in some places a subshell was used which even though was setting some vars, they werent being bubbled up hence in future calls it would need to recompute the same value again

dropping the subshell so that global vars can be permisisted