### PR TITLE
feat: add --saas option

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -112,6 +112,8 @@ load=${CHALK_LOAD:-}
 params=${CHALK_PARAMS:-}
 # whether to automatically determine token via openid connect
 connect=${CHALK_CONNECT:-}
+# saas connect mode - no sensitive tokens are stored in chalk
+saas=${CHALK_SAAS:-}
 # name of the custom profile to load
 profile=${CHALK_PROFILE:-default}
 # CrashOverride API token
@@ -457,7 +459,7 @@ load_custom_profile() {
         --request POST \
         --header "Authorization: bearer $token" \
         --dump-header "$headers" \
-        "$CHALKAPI_HOST/v0.1/profile?chalkVersion=$(chalk_version)&chalkProfileKey=$profile&os=$os&architecture=$arch" \
+        "$CHALKAPI_HOST/v0.1/profile?chalkVersion=$(chalk_version)&chalkProfileKey=$profile&os=$os&architecture=$arch&saas=${saas:-false}" \
         > "$result" \
         || (
             error Could not retrieve custom Chalk profile.
@@ -711,6 +713,9 @@ Args:
                        directly via a parameter or CHALK_OIDC env var.
                        Currently supports:
                        * GitLab (requires using id_tokens)
+--saas                 Connect chalk in SAAS mode where no sensitive
+                       tokens are stored in chalk but it can still
+                       send reports to SAAS providers CrashOverride workspace.
 --token=*              CrashOverride API token when OpenID Connect
                        cannot be used.
 --prefix=*             Where to install Chalk and related
@@ -762,6 +767,9 @@ for arg; do
             ;;
         --connect)
             connect=true
+            ;;
+        --saas)
+            saas=true
             ;;
         --profile=*)
             profile=${arg##*=}

--- a/setup.sh
+++ b/setup.sh
@@ -508,7 +508,7 @@ load_custom_profile() {
             fatal "$(cat "$parameters")"
         )
     params=- load_config "$component" < "$parameters"
-    if [ "$run_setup" = "true" ]; then
+    if [ -z "$saas" ] && [ "$run_setup" = "true" ]; then
         info "Setting up CrashOverride Chalk attestation"
         chalk setup
     fi
@@ -597,8 +597,8 @@ install_chalk() {
     chalk_path=$chalk_tmp chalk version
     info Installing Chalk to "$chalk_path"
     $SUDO mkdir -p "$(dirname "$chalk_path")"
-    $SUDO cp "$chalk_tmp" "$chalk_path"
     $SUDO chmod +xr "$chalk_tmp"
+    $SUDO cp "$chalk_tmp" "$chalk_path"
 }
 
 # load custom Chalk config
@@ -755,6 +755,8 @@ Args:
                        CHALK_PASSWORD env var.
 --setup                Run Chalk setup. Also setup automatically runs
                        if --public-key and --private-key are provided.
+                       Mutually exclusive with --saas as it disables
+                       seting up chalk's attestation.
 --latest-version-url=* URL to get latest chalk version if
                        --version is not provided.
                        Default is '${latest_version_url}'.
@@ -918,11 +920,11 @@ if [ -n "$debug" ]; then
     params='' load_config https://chalkdust.io/debug.c4m
 fi
 
-if [ -n "$password" ] && [ -f "$public_key" ] && [ -f "$private_key" ]; then
+if [ -z "$saas" ] && [ -n "$password" ] && [ -f "$public_key" ] && [ -f "$private_key" ]; then
     info "Loading signing keys into Chalk"
     copy_keys
     chalk setup
-elif [ -n "$setup" ]; then
+elif [ -z "$saas" ] && [ -n "$setup" ]; then
     info "Setting up Chalk attestation"
     chalk setup
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -178,6 +178,10 @@ if [ -n "${__CHALK_TESTING__:-}" ]; then
 fi
 
 retry() {
+    # parsing most important args just for prettier retry error logs
+    # we care about:
+    # * cmd being ran
+    # * first positional arg
     cmd=
     first=
     _kwarg=

--- a/setup.sh
+++ b/setup.sh
@@ -82,7 +82,7 @@ mktemp() {
 cleanup() {
     if [ -f "$tmp_files" ]; then
         while IFS= read -r f; do
-            rm "$f" || true
+            rm "$f"* || true
         done < "$tmp_files"
         rm "$tmp_files" || true
     fi
@@ -580,6 +580,7 @@ download_chalk() {
     if ! [ -f "$chalk_tmp" ]; then
         return 1
     fi
+    echo "$chalk_tmp" >> "$tmp_files"
     checksum=$(cat "$chalk_tmp.sha256")
     info Validating sha256 checksum "${checksum%% *}"
     (


### PR DESCRIPTION
connecting `chalk` to CrashOverride can embed sensitive information into chalk such as its easy attestation mode token

`--saas` option disables all sensitive tokens and only leaves necessary tokens for chalk to send a report out which includes:

* reporting api
* object store api

in addition this PR fixes some bugs when using `setup.sh` to load chalk binary locally something like:

```sh
➜ setup.sh --chalk-path=./chalk --no-wrap --saas --connect --token=...
```
