### PR TITLE
add input to allow to fail bobs setup

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -129,6 +129,7 @@ jobs:
         with:
           connect: true
           profile: setup-chalk-action
+          observables_continue_on_error: false
           load: |
             .github/config.c4m
 

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,11 @@ inputs:
       Version of the observables action to use. Defaults to main.
     required: false
     default: main
+  observables_continue_on_error:
+    description: |
+      Whether to continue or fail build when observables setup fails.
+    required: false
+    default: true
 
 runs:
   using: "composite"
@@ -205,7 +210,7 @@ runs:
     - name: Set up build observables
       if: env.__CHALK_ALREADY_SETUP__ == '' && runner.os == 'Linux' && steps.chalk.outputs.setup_build_observables == 'true'
       uses: ./.tmp-observe
-      continue-on-error: true
+      continue-on-error: ${{ inputs.observables_continue_on_error }}
 
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
     # in some cases chalk needs to auth to GitHub API and it requires


### PR DESCRIPTION
bobs setup can fail now if opted into via:

```yaml
      - name: Setup Chalk
        uses: ./
        with:
          observables_continue_on_error: false
```