### PR TITLE
pin cosign to 2.2.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -115,6 +115,8 @@ runs:
       # most likely bash is missing
       # https://github.com/sigstore/cosign-installer/issues/190
       continue-on-error: true
+      with:
+        cosign-release: v2.2.3
 
     - name: Set CHALK_PASSWORD
       if: env.__CHALK_ALREADY_SETUP__ == '' && (runner.os == 'Linux' || runner.os == 'macOS') && inputs.password != ''


### PR DESCRIPTION
its the version which chalk currently uses and works with