### PR TITLE
find default --prefix with applicable permissions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,8 @@ indent_size = 2
 [*.sh]
 indent_style = space
 indent_size = 4
+
+[Makefile]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -15,8 +15,11 @@ DEPS+=chalk.key
 endif
 
 define SETUP=
-set -x && ./setup.sh
+set -x &&
 endef
+ifneq "$(NOSUDO)" ""
+SETUP+=sudo rm $$(which sudo) &&
+endif
 define CHECK=
 && command -v chalk \
 && chalk version \
@@ -30,6 +33,7 @@ all: prefix
 default: $(DEPS)
 	$(DOCKER) '\
 		$(SETUP) \
+		./setup.sh \
 		--version=$(VERSION) \
 		--load="$(LOAD)" \
 		--params='$(subst ",\\\",$(PARAMS))' \
@@ -42,13 +46,19 @@ prefix: USER=runner
 prefix: $(DEPS)
 	$(DOCKER) '\
 		$(SETUP) \
+		./setup.sh \
 		--version=$(VERSION) \
 		--load="$(LOAD)" \
 		--params='$(subst ",\\\",$(PARAMS))' \
 		--token=$(TOKEN) \
-		--prefix=~/.chalk/bin \
 		$(ARGS) \
 		$(CHECK) \
+	'
+
+help:
+	$(DOCKER) '\
+		$(SETUP) \
+		./setup.sh --help \
 	'
 
 fedora ubuntu alpine:


### PR DESCRIPTION
When sudo is missing and `setup.sh` runs as non-root, `/usr/local` is not a good default prefix as it will not work due to missing permissions.

In these cases attempt to look for an applicable folder on `$PATH` to which the user has `rwx` permissions. For example that can match `~/.local/bin`