### PR TITLE
fix: normalize --chalk-path to an absolute path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -949,7 +949,7 @@ while [ "$n" -gt 0 ]; do
             prefix=$(realpath "$prefix")
             ;;
         --chalk-path)
-            chalk_path=$1
+            chalk_path=$(realpath "$1")
             ;;
         --no-wrap)
             wrap=


### PR DESCRIPTION
otherwise --chalk-path=chalk updates existing chalk binary if any on $PATH instead of creating ./chalk