### PR TITLE
feat: add identifying User-Agent header to all curl calls

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -386,7 +386,7 @@ else
             fi
             if is_installed git; then
                 if [ -n "${GITHUB_ACTION_PATH:-}" ]; then
-                    _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$(git -C "$GITHUB_ACTION_PATH" --no-pager log -n1 --pretty=format:%H 2> /dev/null)"
+                    _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$(git -c safe.directory="$GITHUB_ACTION_PATH" -C "$GITHUB_ACTION_PATH" --no-pager log -n1 --pretty=format:%H 2> /dev/null)"
                 else
                     case "$0" in
                         *.sh)

--- a/setup.sh
+++ b/setup.sh
@@ -374,7 +374,36 @@ if ! is_installed curl; then
         fatal curl is not installed
     }
 else
+    _CURL_UA_BASE=
     curl() {
+        if [ -z "$_CURL_UA_BASE" ]; then
+            # curl[/<version>] [setup-chalk-action-commit/<ref>] [setup-hash/<hash>]
+            _curl_version=$(command curl --version 2> /dev/null | awk 'NR==1{print $2}')
+            if [ -n "$_curl_version" ]; then
+                _CURL_UA_BASE="curl/$_curl_version"
+            else
+                _CURL_UA_BASE="curl"
+            fi
+            if is_installed git; then
+                if [ -n "${GITHUB_ACTION_PATH:-}" ]; then
+                    _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$(git -C "$GITHUB_ACTION_PATH" --no-pager log -n1 --pretty=format:%H 2> /dev/null)"
+                else
+                    case "$0" in
+                        *.sh)
+                            if git -C "$(dirname "$0")" ls-files --error-unmatch "$0" > /dev/null 2>&1; then
+                                _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$(git -C "$(dirname "$0")" --no-pager log -n1 --pretty=format:%H 2> /dev/null)"
+                            fi
+                            ;;
+                    esac
+                fi
+            fi
+            case "$0" in
+                *.sh)
+                    _CURL_UA_BASE="$_CURL_UA_BASE setup-hash/$($SHA256 "$0" 2> /dev/null | awk '{print $1}')"
+                    ;;
+            esac
+        fi
+        CURL_UA="$_CURL_UA_BASE${version:+ chalk/$version}"
         _tmperr=$(mktemp curl_err.XXXXXX)
         _url=$(first_arg "$@")
         # --write-out '%{http_code}' requires --output to avoid mixing the
@@ -388,7 +417,7 @@ else
             set -- "$@" "--output" "$_curl_output"
         fi
         if ! _http_code=$(
-            command curl --write-out '%{http_code}' "$@" 2> "$_tmperr"
+            command curl --write-out '%{http_code}' -A "$CURL_UA" "$@" 2> "$_tmperr"
         ); then
             # Transport error (DNS, timeout, connection refused): copy stderr to
             # both the console and the output file so fatal_curl can surface it.

--- a/setup.sh
+++ b/setup.sh
@@ -386,12 +386,18 @@ else
             fi
             if is_installed git; then
                 if [ -n "${GITHUB_ACTION_PATH:-}" ]; then
-                    _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$(git -c safe.directory="$GITHUB_ACTION_PATH" -C "$GITHUB_ACTION_PATH" --no-pager log -n1 --pretty=format:%H 2> /dev/null)"
+                    _commit=$(git -c safe.directory="$GITHUB_ACTION_PATH" -C "$GITHUB_ACTION_PATH" --no-pager log -n1 --pretty=format:%H 2> /dev/null)
+                    if [ -n "$_commit" ]; then
+                        _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$_commit"
+                    fi
                 else
                     case "$0" in
                         *.sh)
                             if git -C "$(dirname "$0")" ls-files --error-unmatch "$0" > /dev/null 2>&1; then
-                                _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$(git -C "$(dirname "$0")" --no-pager log -n1 --pretty=format:%H 2> /dev/null)"
+                                _commit=$(git -C "$(dirname "$0")" --no-pager log -n1 --pretty=format:%H 2> /dev/null)
+                                if [ -n "$_commit" ]; then
+                                    _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$_commit"
+                                fi
                             fi
                             ;;
                     esac
@@ -399,11 +405,14 @@ else
             fi
             case "$0" in
                 *.sh)
-                    _CURL_UA_BASE="$_CURL_UA_BASE setup-hash/$($SHA256 "$0" 2> /dev/null | awk '{print $1}')"
+                    _hash=$($SHA256 "$0" 2> /dev/null | awk '{print $1}')
+                    if [ -n "$_hash" ]; then
+                        _CURL_UA_BASE="$_CURL_UA_BASE setup-hash/$_hash"
+                    fi
                     ;;
             esac
         fi
-        CURL_UA="$_CURL_UA_BASE${version:+ chalk/$version}"
+        _CURL_UA="$_CURL_UA_BASE${version:+ chalk/$version}"
         _tmperr=$(mktemp curl_err.XXXXXX)
         _url=$(first_arg "$@")
         # --write-out '%{http_code}' requires --output to avoid mixing the
@@ -417,7 +426,7 @@ else
             set -- "$@" "--output" "$_curl_output"
         fi
         if ! _http_code=$(
-            command curl --write-out '%{http_code}' -A "$CURL_UA" "$@" 2> "$_tmperr"
+            command curl --write-out '%{http_code}' -A "$_CURL_UA" "$@" 2> "$_tmperr"
         ); then
             # Transport error (DNS, timeout, connection refused): copy stderr to
             # both the console and the output file so fatal_curl can surface it.

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,6 +5,7 @@ ARG BASE
 FROM alpine AS alpine
 RUN apk add --no-cache \
     curl \
+    git \
     sudo
 
 RUN addgroup sudo
@@ -18,6 +19,7 @@ RUN apt-get update && \
     apt-get install -y \
         adduser \
         curl \
+        git \
         sudo \
         && \
     apt-get clean
@@ -28,7 +30,8 @@ RUN adduser --home /home/runner --ingroup sudo runner
 
 FROM fedora AS fedora
 RUN yum install \
-    curl
+    curl \
+    git
 
 RUN groupadd sudo
 RUN adduser runner --home-dir /home/runner --groups sudo


### PR DESCRIPTION
## Summary

- Builds a `User-Agent` header lazily on first curl call and injects it into every request via the `curl()` wrapper
- Static parts (curl version, action commit, setup hash) are cached in `_CURL_UA_BASE`; chalk version is appended dynamically per-call once known
- Format: `curl/<version> setup-chalk-action-commit/<sha> setup-hash/<file-sha> chalk/<version>`

## Details

- **curl version**: probed via `curl --version` at runtime; gracefully omitted if unavailable
- **setup-chalk-action-commit**: read from `GITHUB_ACTION_PATH` (inside the GitHub Action) or from the git repo containing `$0` (local dev), verified via `git ls-files --error-unmatch` to avoid reporting commits from unrelated repos
- **setup-hash**: sha256 of the script file itself, only included when `$0` matches `*.sh` (skipped for piped/process-substitution invocations where the fd is consumed before the script runs)
- **chalk version**: appended via `${version:+ chalk/$version}` so it appears only after the version is resolved mid-run
- `git` added to all base images in `tests/Dockerfile` to support the action-commit lookup

## Test plan

- [ ] Run `make -C tests default DEBUG=true` and verify `User-Agent` header appears in curl trace with all expected tokens
- [ ] Verify `setup-hash` matches `sha256sum setup.sh` locally
- [ ] Verify `setup-chalk-action-commit` matches `git log -n1` on the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)