### PR TITLE
fix: add setup-chalk-action-ref to UA; handle tarball action download

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -384,24 +384,25 @@ else
             else
                 _CURL_UA_BASE="curl"
             fi
-            if is_installed git; then
-                if [ -n "${GITHUB_ACTION_PATH:-}" ]; then
+            if [ -n "${GITHUB_ACTION_PATH:-}" ]; then
+                _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-ref/$(basename "$GITHUB_ACTION_PATH")"
+                if is_installed git; then
                     _commit=$(git -c safe.directory="$GITHUB_ACTION_PATH" -C "$GITHUB_ACTION_PATH" --no-pager log -n1 --pretty=format:%H 2> /dev/null)
                     if [ -n "$_commit" ]; then
                         _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$_commit"
                     fi
-                else
-                    case "$0" in
-                        *.sh)
-                            if git -C "$(dirname "$0")" ls-files --error-unmatch "$0" > /dev/null 2>&1; then
-                                _commit=$(git -C "$(dirname "$0")" --no-pager log -n1 --pretty=format:%H 2> /dev/null)
-                                if [ -n "$_commit" ]; then
-                                    _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$_commit"
-                                fi
-                            fi
-                            ;;
-                    esac
                 fi
+            elif is_installed git; then
+                case "$0" in
+                    *.sh)
+                        if git -C "$(dirname "$0")" ls-files --error-unmatch "$0" > /dev/null 2>&1; then
+                            _commit=$(git -C "$(dirname "$0")" --no-pager log -n1 --pretty=format:%H 2> /dev/null)
+                            if [ -n "$_commit" ]; then
+                                _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$_commit"
+                            fi
+                        fi
+                        ;;
+                esac
             fi
             case "$0" in
                 *.sh)


### PR DESCRIPTION
## Summary

- Adds `setup-chalk-action-ref/<ref>` token to the User-Agent (e.g. `main`, `v1.2.3`), derived from `basename(GITHUB_ACTION_PATH)` — always available in GitHub Actions
- Keeps `setup-chalk-action-commit/<sha>` for cases where a real git repo exists (local dev)

## Why the previous commit was incomplete

GitHub Actions downloads actions as tarballs, not git clones — there is no `.git` directory at `GITHUB_ACTION_PATH`. So `git log` always returns empty and `setup-chalk-action-commit` was blank. The ref from `basename(GITHUB_ACTION_PATH)` is always available and fills that gap.

## Test plan

- [ ] Verify `setup-chalk-action-ref/main` appears in the User-Agent in a GitHub Actions run
- [ ] Verify `setup-chalk-action-commit/<sha>` still appears when running locally from a git checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)