### PR TITLE
fix: guard $0 hash/commit checks against non-regular files

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -395,7 +395,7 @@ else
             elif is_installed git; then
                 case "$0" in
                     *.sh)
-                        if git -C "$(dirname "$0")" ls-files --error-unmatch "$0" > /dev/null 2>&1; then
+                        if [ -f "$0" ] && git -C "$(dirname "$0")" ls-files --error-unmatch "$0" > /dev/null 2>&1; then
                             _commit=$(git -C "$(dirname "$0")" --no-pager log -n1 --pretty=format:%H 2> /dev/null)
                             if [ -n "$_commit" ]; then
                                 _CURL_UA_BASE="$_CURL_UA_BASE setup-chalk-action-commit/$_commit"
@@ -406,9 +406,11 @@ else
             fi
             case "$0" in
                 *.sh)
-                    _hash=$($SHA256 "$0" 2> /dev/null | awk '{print $1}')
-                    if [ -n "$_hash" ]; then
-                        _CURL_UA_BASE="$_CURL_UA_BASE setup-hash/$_hash"
+                    if [ -f "$0" ]; then
+                        _hash=$($SHA256 "$0" 2> /dev/null | awk '{print $1}')
+                        if [ -n "$_hash" ]; then
+                            _CURL_UA_BASE="$_CURL_UA_BASE setup-hash/$_hash"
+                        fi
                     fi
                     ;;
             esac


### PR DESCRIPTION
## Summary

- The `*.sh)` case arms that compute the script hash and git commit for the User-Agent header now first verify `[ -f "$0" ]` before proceeding
- This prevents false positives when `$0` matches `*.sh` but is actually a pipe (e.g. fish shell process substitution with a custom file suffix), which would cause `sha256sum` or `git ls-files` to operate on a FIFO rather than a real file

## Test plan

- [ ] Confirm normal invocation (`bash setup.sh`) still populates `setup-hash/` and `setup-chalk-action-commit/` in the UA header
- [ ] Confirm invocation via fish process substitution with a `.sh`-suffixed FIFO no longer attempts to hash or git-check the pipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)